### PR TITLE
Ignore null object attributes

### DIFF
--- a/elems.js
+++ b/elems.js
@@ -91,6 +91,10 @@ export function elemGenerator(tag, ns)
 					{
 						elem.setAttribute( key, arg[key] );
 					}
+					else if ( arg[key] === null )
+					{
+						return;
+					}
 					else
 					{
 						throw 'Invalid type for attribute ' + key + ' in element ' + tag;


### PR DESCRIPTION
This is useful for boolean attributes where any value is considered true, including false. For example:

input(
    { type: 'checkbox' },
    { checked: power === 'on' ? true : null },
)