### PR TITLE
Update attribute handling for booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,17 @@ types, and builds up the element according to them.
 
 *Objects*:
   Objects with iterable keys will be treated as attribute and event maps.
-  Values which are strings are treated as attributes, values that are
-  functions are treated as event handlers. `null`s in the iteration will
-  be treated as values which should be ignored.
+
+  Values which are function are treated as event handlers. This uses
+  `addEventListener`, so the `on` part of the event name should not be
+  a part of the key.
+
+  Other values are are coerced to strings and treated as attributes, with
+  a few exceptions:
+   - `null` causes no action to happen.
+   - a boolean causes that value to be set without a value (true) or,
+     the attribute to be removed (false).
+   - objects and array cause and exception.
 
 Providing any other type in an argument will result in an exception being thrown.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ types, and builds up the element according to them.
 *Objects*:
   Objects with iterable keys will be treated as attribute and event maps.
 
-  Values which are function are treated as event handlers. This uses
+  Values which are functions are treated as event handlers. This uses
   `addEventListener`, so the `on` part of the event name should not be
   a part of the key.
 
@@ -98,7 +98,7 @@ types, and builds up the element according to them.
    - `null` causes no action to happen.
    - a boolean causes that value to be set without a value (true) or,
      the attribute to be removed (false).
-   - objects and array cause and exception.
+   - objects and array cause an exception.
 
 Providing any other type in an argument will result in an exception being thrown.
 

--- a/elems.js
+++ b/elems.js
@@ -25,9 +25,17 @@
  *
  * Objects:
  *   Objects with iterable keys will be treated as attribute and event maps.
- *   Values which are strings are treated as attributes, values that are
- *   functions are treated as event handlers. `null`s in the iteration will
- *   be treated as values which should be ignored.
+ *
+ *   Values which are function are treated as event handlers. This uses
+ *   `addEventListener`, so the `on` part of the event name should not be
+ *   a part of the key.
+ *
+ *   Other values are are coerced to strings and treated as attributes, with
+ *   a few exceptions:
+ *    - `null` causes no action to happen.
+ *    - a boolean causes that value to be set without a value (true) or,
+ *      the attribute to be removed (false).
+ *    - objects and array cause and exception.
  *
  * Providing any other type in an argument will result in an exception being thrown.
  *
@@ -88,13 +96,21 @@ export function elemGenerator(tag, ns)
 					{
 						elem.addEventListener( key, arg[key] );
 					}
-					else if ( typeof arg[key] !== 'object' )
+					else if ( arg[key] === true )
 					{
-						elem.setAttribute( key, arg[key] );
+						elem.setAttribute( key, "" );
+					}
+					else if ( arg[key] === false )
+					{
+						elem.removeAttribute( key );
 					}
 					else if ( arg[key] === null )
 					{
 						return;
+					}
+					else if ( typeof arg[key] !== 'object' )
+					{
+						elem.setAttribute( key, arg[key] );
 					}
 					else
 					{

--- a/elems.js
+++ b/elems.js
@@ -26,7 +26,7 @@
  * Objects:
  *   Objects with iterable keys will be treated as attribute and event maps.
  *
- *   Values which are function are treated as event handlers. This uses
+ *   Values which are functions are treated as event handlers. This uses
  *   `addEventListener`, so the `on` part of the event name should not be
  *   a part of the key.
  *
@@ -35,7 +35,7 @@
  *    - `null` causes no action to happen.
  *    - a boolean causes that value to be set without a value (true) or,
  *      the attribute to be removed (false).
- *    - objects and array cause and exception.
+ *    - objects and array cause an exception.
  *
  * Providing any other type in an argument will result in an exception being thrown.
  *

--- a/elems.js
+++ b/elems.js
@@ -98,7 +98,7 @@ export function elemGenerator(tag, ns)
 					}
 					else if ( arg[key] === true )
 					{
-						elem.setAttribute( key, "" );
+						elem.setAttribute( key, '' );
 					}
 					else if ( arg[key] === false )
 					{


### PR DESCRIPTION
When an attribute is attempted to be set to `true`, it is set as if it were a boolean attribute, such as
```xml
<element foo />
```
This is consistent with most expectations of boolean handling.

The behaviour of false is to remove the attribute (assuming it is set). This might be used where a pipeline is generating a series of similar elements, and a feature is then turned off for some of them.

Finally, the documentation around the use of `null` has been made clearer: it leaves the attribute as it currently is, perform no action.

Additionally, the `null` check has been moved above the `typeof !== object`; although `null` is an object in JS, the ordering this left read weirdly and looked like a bug at first sight.